### PR TITLE
OCaml 4.12 support: Rearrange types to support the new injectivity annotations in Map.S

### DIFF
--- a/src/fpath.mli
+++ b/src/fpath.mli
@@ -507,58 +507,51 @@ module Set : sig
         [ppf]. *)
 end
 
-type +'a map
-(** The type for maps from paths to values of type ['a]. Paths are compared
-    with {!compare}. *)
-
 (** Path maps. *)
 module Map : sig
 
   (** {1 Path maps} *)
 
   include Map.S with type key := t
-                 and type 'a t := 'a map
 
-  type 'a t = 'a map
-
-  val min_binding : 'a map -> (path * 'a) option
+  val min_binding : 'a t -> (path * 'a) option
   (** Exception safe {!Map.S.min_binding}. *)
 
-  val get_min_binding : 'a map -> (path * 'a)
+  val get_min_binding : 'a t -> (path * 'a)
   (** [get_min_binding] is like {!min_binding} but @raise Invalid_argument
       on the empty map. *)
 
-  val max_binding : 'a map -> (path * 'a) option
+  val max_binding : 'a t -> (path * 'a) option
   (** Exception safe {!Map.S.max_binding}. *)
 
-  val get_max_binding : 'a map -> string * 'a
+  val get_max_binding : 'a t -> string * 'a
   (** [get_min_binding] is like {!max_binding} but @raise Invalid_argument
       on the empty map. *)
 
-  val choose : 'a map -> (path * 'a) option
+  val choose : 'a t -> (path * 'a) option
   (** Exception safe {!Map.S.choose}. *)
 
-  val get_any_binding : 'a map -> (path * 'a)
+  val get_any_binding : 'a t -> (path * 'a)
   (** [get_any_binding] is like {!choose} but @raise Invalid_argument
       on the empty map. *)
 
-  val find : path -> 'a map -> 'a option
+  val find : path -> 'a t -> 'a option
   (** Exception safe {!Map.S.find}. *)
 
-  val get : path -> 'a map -> 'a
+  val get : path -> 'a t -> 'a
   (** [get k m] is like {!Map.S.find} but raises [Invalid_argument] if
       [k] is not bound in [m]. *)
 
-  val dom : 'a map -> set
+  val dom : 'a t -> set
   (** [dom m] is the domain of [m]. *)
 
-  val of_list : (path * 'a) list -> 'a map
+  val of_list : (path * 'a) list -> 'a t
   (** [of_list bs] is [List.fold_left (fun m (k, v) -> add k v m) empty
       bs]. *)
 
   val pp : ?sep:(Format.formatter -> unit -> unit) ->
     (Format.formatter -> path * 'a -> unit) -> Format.formatter ->
-    'a map -> unit
+    'a t -> unit
   (** [pp ~sep pp_binding ppf m] formats the bindings of [m] on
       [ppf]. Each binding is formatted with [pp_binding] and
       bindings are separated by [sep] (defaults to
@@ -566,10 +559,14 @@ module Map : sig
       untouched. *)
 
   val dump : (Format.formatter -> 'a -> unit) -> Format.formatter ->
-    'a map -> unit
+    'a t -> unit
   (** [dump pp_v ppf m] prints an unspecified representation of [m] on
         [ppf] using [pp_v] to print the map codomain elements. *)
 end
+
+type +'a map = 'a Map.t
+(** The type for maps from paths to values of type ['a]. Paths are compared
+    with {!compare}. *)
 
 (** {1:tips Tips}
 


### PR DESCRIPTION
Currently `fpath` fails to compile on OCaml 4.12 with:
```
+ ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -package astring -package result -I src -I test -o src/fpath.cmi src/fpath.mli
File "src/fpath.mli", lines 519-520, characters 10-40:
519 | ..........Map.S with type key := t
520 |                  and type 'a t := 'a map
Error: In this `with' constraint, the new definition of t
       does not match its original definition in the constrained signature:
       Type declarations do not match:
         type 'a t = 'a map
       is not included in
         type +!'a t
       Their variances do not agree.
       File "map.mli", line 67, characters 4-15: Expected declaration
       File "src/fpath.mli", line 520, characters 21-40: Actual declaration
```
This PR simply fixes the issue the same way it was fixed for `astring`: https://github.com/dbuenzli/astring/commit/ec7a266a3a680e5d246689855c639da53d713428